### PR TITLE
publish image for supporting arm64 and amd64

### DIFF
--- a/.github/workflows/docker-image-ghcr.yml
+++ b/.github/workflows/docker-image-ghcr.yml
@@ -13,11 +13,21 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
         username: ${{github.actor}}
         password: ${{secrets.GH_TOKEN}}
-    - name: Build and publish the Docker image
-      run: make docker-build docker-push
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: digicert-issuer:latest
+        


### PR DESCRIPTION
refer to https://docs.docker.com/build/ci/github-actions/multi-platform/

I have test the docker build arm64 and amd64 on my local as the screenshot.
![image](https://github.com/sapcc/digicert-issuer/assets/17400718/26c48fd5-cec3-4ac6-a24b-47d9a7579a43)
