### PR TITLE
Fix certificaterequest controller group test

### DIFF
--- a/controllers/certmanager/certificaterequest_controller.go
+++ b/controllers/certmanager/certificaterequest_controller.go
@@ -92,7 +92,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Check the CertificateRequest's issuerRef and if it does not match the api
 	// group name, log a message at a debug level and stop processing.
-	if cr.Spec.IssuerRef.Group != "" && cr.Spec.IssuerRef.Group != certmanagerv1beta1.GroupVersion.Group {
+	if cr.Spec.IssuerRef.Group != certmanagerv1beta1.GroupVersion.Group {
 		log.V(4).Info("resource does not specify an issuerRef group name that we are responsible for", "group", cr.Spec.IssuerRef.Group)
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
cert-manager is creating certificaterequests without a group set in issuerRef for self-signed certificates and digicert-issuer is messing up those requests.
cc @auhlig @kayrus 