### PR TITLE
Strip managed fields from cached objects

### DIFF
--- a/cmd/digicert-issuer/main.go
+++ b/cmd/digicert-issuer/main.go
@@ -34,6 +34,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	// +kubebuilder:scaffold:imports
@@ -89,6 +90,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Cache:  cache.Options{DefaultTransform: cache.TransformStripManagedFields()},
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,


### PR DESCRIPTION
To reduce memory consumption, managed fields (managed by API server) get removed from cached objects.
Documentation: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache#TransformStripManagedFields