### PR TITLE
Fix order type and payment method mappings

### DIFF
--- a/controllers/certmanager/suite_test.go
+++ b/controllers/certmanager/suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(k8sClient).ToNot(BeNil())
 
 	close(done)
-}, 60)
+})
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/provisioners/util.go
+++ b/pkg/provisioners/util.go
@@ -37,13 +37,12 @@ func mapToOrderType(s string) (certcentral.OrderType, bool) {
 }
 
 func listAvailableOrderTypes() []certcentral.OrderType {
-	orderTypes := reflect.Indirect(reflect.ValueOf(certcentral.OrderTypes))
-	len := orderTypes.NumField()
-	allTypes := make([]certcentral.OrderType, len)
-	for i := 0; i < len; i++ {
-		allTypes[i] = certcentral.OrderType(orderTypes.Type().Field(i).Name)
+	var orderTypes []certcentral.OrderType
+	v := reflect.ValueOf(certcentral.OrderTypes)
+	for i := 0; i < v.NumField(); i++ {
+		orderTypes = append(orderTypes, v.Field(i).Interface().(certcentral.OrderType))
 	}
-	return allTypes
+	return orderTypes
 }
 
 func mapToPaymentMethod(s string) (certcentral.PaymentMethod, bool) {
@@ -57,11 +56,10 @@ func mapToPaymentMethod(s string) (certcentral.PaymentMethod, bool) {
 }
 
 func listAvailablePaymentMethods() []certcentral.PaymentMethod {
-	paymentMethods := reflect.Indirect(reflect.ValueOf(certcentral.PaymentMethods))
-	len := paymentMethods.NumField()
-	allMethods := make([]certcentral.PaymentMethod, len)
-	for i := 0; i < len; i++ {
-		allMethods[i] = certcentral.PaymentMethod(paymentMethods.Type().Field(i).Name)
+	var paymentMethods []certcentral.PaymentMethod
+	v := reflect.ValueOf(certcentral.PaymentMethods)
+	for i := 0; i < v.NumField(); i++ {
+		paymentMethods = append(paymentMethods, v.Field(i).Interface().(certcentral.PaymentMethod))
 	}
-	return allMethods
+	return paymentMethods
 }

--- a/pkg/provisioners/util_test.go
+++ b/pkg/provisioners/util_test.go
@@ -1,0 +1,42 @@
+package provisioners
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	certcentral "github.com/sapcc/go-certcentral"
+)
+
+func TestProvisioners(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Provisioners Suite")
+}
+
+var _ = Describe("Map Payment Method", func() {
+	It("should map existing payment method string to correct payment method", func() {
+		paymentMethod, found := mapToPaymentMethod("wire_transfer")
+		Expect(paymentMethod).To(Equal(certcentral.PaymentMethods.WireTransfer))
+		Expect(found).To(BeTrue())
+	})
+
+	It("should return false for non-existing payment method string", func() {
+		paymentMethod, found := mapToPaymentMethod("non_existing_method")
+		Expect(paymentMethod).To(BeEmpty())
+		Expect(found).To(BeFalse())
+	})
+})
+
+var _ = Describe("Map Order Type", func() {
+	It("should map existing order type string to correct order type", func() {
+		orderType, found := mapToOrderType("ssl_ev_securesite_pro")
+		Expect(orderType).To(Equal(certcentral.OrderTypes.SecureSiteProEVSSL))
+		Expect(found).To(BeTrue())
+	})
+
+	It("should return false for non-existing order type string", func() {
+		orderType, found := mapToOrderType("non_existing_type")
+		Expect(orderType).To(BeEmpty())
+		Expect(found).To(BeFalse())
+	})
+})

--- a/pkg/provisioners/util_test.go
+++ b/pkg/provisioners/util_test.go
@@ -1,3 +1,22 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and sapcc contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Copyright 2022 SAP SE.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package provisioners
 
 import (


### PR DESCRIPTION
This fixes #57. I added some tests describing the expectations.

Additionally, remove the 60 from the BeforeSuite call, as it produced the error/warning `[BeforeSuite] node was passed an unknown decorator: '60'`