### PR TITLE
core: introduce cache-sync-timeout optional argument

### DIFF
--- a/cmd/digicert-issuer/main.go
+++ b/cmd/digicert-issuer/main.go
@@ -64,6 +64,7 @@ func main() {
 		printVersionAndExit                bool
 		backoffDurationProvisionerNotReady time.Duration
 		backoffDurationRequestPending      time.Duration
+		cacheSyncTimeout                   time.Duration
 		clusterIssuerNamespace             string
 		disableRootCA                      bool
 	)
@@ -79,6 +80,9 @@ func main() {
 
 	flag.DurationVar(&backoffDurationRequestPending, "backoff-duration-request-pending", 15*time.Minute,
 		"The backoff duration if certificate request is pending.")
+
+	flag.DurationVar(&cacheSyncTimeout, "cache-sync-timeout", 2*time.Minute,
+		"The timeout on waiting for cache to sync.")
 
 	flag.StringVar(&clusterIssuerNamespace, "cluster-issuer-namespace", "",
 		"Namespace, from which clusterdigicertissuer secret are read for ClusterDigicertIssuers. If left empty, ClusterDigicertIssuer is not reconciled.")
@@ -117,6 +121,7 @@ func main() {
 	err = (&certmanagerv1beta1controller.CertificateRequestReconciler{
 		BackoffDurationProvisionerNotReady: backoffDurationProvisionerNotReady,
 		BackoffDurationRequestPending:      backoffDurationRequestPending,
+		CacheSyncTimeout:                   cacheSyncTimeout,
 		DefaultProviderNamespace:           getValueFromEnvironmentOrDefault("POD_NAMESPACE", "kube-system"),
 		DisableRootCA:                      disableRootCA,
 	}).SetupWithManager(mgr)

--- a/controllers/certmanager/certificaterequest_controller.go
+++ b/controllers/certmanager/certificaterequest_controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -48,6 +49,7 @@ type CertificateRequestReconciler struct {
 	log                                logr.Logger
 	BackoffDurationProvisionerNotReady time.Duration
 	BackoffDurationRequestPending      time.Duration
+	CacheSyncTimeout                   time.Duration
 	recorder                           record.EventRecorder
 	DefaultProviderNamespace           string
 	DisableRootCA                      bool
@@ -76,6 +78,7 @@ func (r *CertificateRequestReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	r.Client = mgr.GetClient()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cmapi.CertificateRequest{}).
+		WithOptions(controller.Options{CacheSyncTimeout: r.CacheSyncTimeout}).
 		WithEventFilter(filter).
 		Complete(r)
 }


### PR DESCRIPTION
This flag allows to increase the controller's `CacheSyncTimeout` to avoid issues during startup and high number of certificate requests causing:

```
2025-10-29T15:18:58Z    ERROR   Could not wait for Cache to sync        {"controller": "certificaterequest", "controllerGroup": "cert-manager.io", "controllerKind": "CertificateRequest", "error": "failed to wait for certificaterequest caches to sync: timed out waiting for cache to be synced for Kind *v1.CertificateRequest"}
```