### PR TITLE
fix: bump Go runtime to 1.26.4 to address CVE-2026-42507

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 as builder
+FROM golang:1.26.4 as builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sapcc/digicert-issuer
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2


### PR DESCRIPTION
## Bump Go runtime to 1.26.4 to address CVE-2026-42507

The published container image was flagged in a security scan for
CVE-2026-42507 in `golang-runtime 1.26.3` (CVSS3: 4.6, Medium).

This PR fixes it by pinning the builder to `golang:1.26.4` in the
Dockerfile and updating `go.mod` to match. 
`go mod tidy` produced no changes. 


**Changes:**
- `Dockerfile`: `FROM golang:1.26` → `FROM golang:1.26.4`
- `go.mod`: `go 1.26.0` → `go 1.26.4`